### PR TITLE
Alternate conditional insert syntax in DISPATCHER_CHECK_MEDIA_SERVER for MySQL

### DIFF
--- a/kamailio/db_queries_kazoo.cfg
+++ b/kamailio/db_queries_kazoo.cfg
@@ -1,0 +1,2 @@
+####### Database queries ########
+#!substdef "!DISPATCHER_CHECK_MEDIA_SERVER_INSERT_QUERY!insert into dispatcher (setid, destination) select \$var(SetId), \"\$var(MediaUrl)\" where not exists(select * from dispatcher where destination = \"\$var(MediaUrl)\")!g"

--- a/kamailio/db_queries_mysql.cfg
+++ b/kamailio/db_queries_mysql.cfg
@@ -1,0 +1,2 @@
+####### Database queries ########
+#!substdef "!DISPATCHER_CHECK_MEDIA_SERVER_INSERT_QUERY!insert into dispatcher (setid, destination) select \$var(SetId), \"\$var(MediaUrl)\" from DUAL where not exists(select * from dispatcher where destination = \"\$var(MediaUrl)\")!g"

--- a/kamailio/defs.cfg
+++ b/kamailio/defs.cfg
@@ -7,6 +7,10 @@
 #!define KAZOO_LOG_LEVEL L_INFO
 #!endif
 
+#!ifndef KAMAILIO_DBMS
+#!substdef "!KAMAILIO_DBMS!kazoo!g"
+#!endif
+
 #!ifndef KAZOO_DATA_DIR
 #!substdef "!KAZOO_DATA_DIR!/etc/kazoo/kamailio/db!g"
 #!endif

--- a/kamailio/dispatcher-role.cfg
+++ b/kamailio/dispatcher-role.cfg
@@ -221,7 +221,12 @@ route[DISPATCHER_CHECK_MEDIA_SERVER]
        if($var(Zone) != "MY_AMQP_ZONE") {
           $var(SetId) = 2;
        }
-       sql_query("exec", "insert into dispatcher (setid, destination) select $var(SetId), \"$var(MediaUrl)\" where not exists(select * from dispatcher where destination = \"$var(MediaUrl)\")");
+       if ("KAZOO_DB_URL" =~ "^mysql") {
+           sql_query("exec", "insert into dispatcher (setid, destination) select $var(SetId), \"$var(MediaUrl)\" from DUAL where not exists(select * from dispatcher where destination = \"$var(MediaUrl)\")");
+       }
+       else {
+           sql_query("exec", "insert into dispatcher (setid, destination) select $var(SetId), \"$var(MediaUrl)\" where not exists(select * from dispatcher where destination = \"$var(MediaUrl)\")");
+       }
        if($sqlrows(exec) > 0) {
           xlog("L_WARNING", "reloading dispatcher table\n");
           ds_reload();

--- a/kamailio/dispatcher-role.cfg
+++ b/kamailio/dispatcher-role.cfg
@@ -221,12 +221,7 @@ route[DISPATCHER_CHECK_MEDIA_SERVER]
        if($var(Zone) != "MY_AMQP_ZONE") {
           $var(SetId) = 2;
        }
-       if ("KAZOO_DB_URL" =~ "^mysql") {
-           sql_query("exec", "insert into dispatcher (setid, destination) select $var(SetId), \"$var(MediaUrl)\" from DUAL where not exists(select * from dispatcher where destination = \"$var(MediaUrl)\")");
-       }
-       else {
-           sql_query("exec", "insert into dispatcher (setid, destination) select $var(SetId), \"$var(MediaUrl)\" where not exists(select * from dispatcher where destination = \"$var(MediaUrl)\")");
-       }
+       sql_query("exec", "DISPATCHER_CHECK_MEDIA_SERVER_INSERT_QUERY");
        if($sqlrows(exec) > 0) {
           xlog("L_WARNING", "reloading dispatcher table\n");
           ds_reload();

--- a/kamailio/kamailio.cfg
+++ b/kamailio/kamailio.cfg
@@ -29,6 +29,9 @@ include_file "local.cfg"
 ####### defaults not configured in local ########
 include_file "defs.cfg"
 
+####### DBMS query selection ########
+include_file "db_queries_KAMAILIO_DBMS.cfg"
+
 ####### Default Configuration ######
 include_file "default.cfg"
 


### PR DESCRIPTION
Using a WHERE clause without a prior FROM clause is invalid syntax in MySQL (see: https://dev.mysql.com/doc/refman/5.5/en/select.html). Recommendation when selecting scalar values is to use FROM DUAL, so I've added that conditionally in dispatcher-role.cfg.