### PR TITLE
PUSHER_ROLE: Continue processing SIP messaging even if push notification sent

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -620,6 +620,12 @@ route[INTERNAL_TO_EXTERNAL_RELAY]
             $du = $(ulc(callee=>received));
             $fs = $(ulc(callee=>socket));
             xlog("L_INFO", "$ci|log|routing $hdr(X-KAZOO-AOR) to $du via $fs\n");
+        } else if ($hdr(X-KAZOO-PUSHER-Token-ID) != $null) {
+            xlog("L_INFO", "$ci|log|ignoring missing registration while waiting for push notification response\n");
+            t_on_reply("EXTERNAL_REPLY");
+            t_set_fr(0, 10000);
+            t_release();
+            exit;
         } else {
             xlog("L_INFO", "$ci|end|user is not registered\n");
             sl_send_reply("404", "Not registered");

--- a/kamailio/pusher-role.cfg
+++ b/kamailio/pusher-role.cfg
@@ -12,6 +12,10 @@ route[PUSHER_ROUTE]
     if ( (!is_method("INVITE")) || (!isflagset(FLAG_INTERNALLY_SOURCED)) || $hdr(X-KAZOO-PUSHER-Token-ID) == $null)
        return;
 
+    if(registered("location") && $hdr(X-KAZOO-PUSHER-Simultaneous-Push-and-Invite) == null) {
+       return;
+    }
+
     xlog("L_INFO", "$ci| pusher received request to wakeup $tu\n");
     sl_send_reply(180, "waking the dead guy");
     if (t_newtran()) {

--- a/kamailio/pusher-role.cfg
+++ b/kamailio/pusher-role.cfg
@@ -3,6 +3,7 @@
 ####### SQL OPS module ##########
 #!ifndef TSILO_LOADED
 loadmodule "tsilo.so"
+modparam("tsilo", "use_domain", 1)
 #!trydef TSILO_LOADED
 #!endif
 
@@ -11,24 +12,16 @@ route[PUSHER_ROUTE]
     if ( (!is_method("INVITE")) || (!isflagset(FLAG_INTERNALLY_SOURCED)) || $hdr(X-KAZOO-PUSHER-Token-ID) == $null)
        return;
 
-    if(registered("location")) {
-       return;
-    }
-       
     xlog("L_INFO", "$ci| pusher received request to wakeup $tu\n");
     sl_send_reply(180, "waking the dead guy");
     if (t_newtran()) {
           route(SEND_PUSH_NOTIFICATION);
-          t_on_reply("EXTERNAL_REPLY");
-          t_set_fr(0, 10000);
           remove_hf_re("^X-.*");
           t_save_lumps();
-          ts_store();
-          t_release();
+          ts_store("$(tu{s.tolower})");
        } else {
           sl_send_reply(500, "error creating transaction for waking the dead guy");
     }
-    exit;
 }
 
 route[SEND_PUSH_NOTIFICATION]

--- a/kamailio/pusher-role.cfg
+++ b/kamailio/pusher-role.cfg
@@ -12,7 +12,7 @@ route[PUSHER_ROUTE]
     if ( (!is_method("INVITE")) || (!isflagset(FLAG_INTERNALLY_SOURCED)) || $hdr(X-KAZOO-PUSHER-Token-ID) == $null)
        return;
 
-    if(registered("location") && $hdr(X-KAZOO-PUSHER-Simultaneous-Push-and-Invite) == $null) {
+    if(registered("location") && $hdr(X-KAZOO-PUSHER-Invite-Format) != "push_and_invite") {
        return;
     }
 

--- a/kamailio/pusher-role.cfg
+++ b/kamailio/pusher-role.cfg
@@ -12,7 +12,7 @@ route[PUSHER_ROUTE]
     if ( (!is_method("INVITE")) || (!isflagset(FLAG_INTERNALLY_SOURCED)) || $hdr(X-KAZOO-PUSHER-Token-ID) == $null)
        return;
 
-    if(registered("location") && $hdr(X-KAZOO-PUSHER-Simultaneous-Push-and-Invite) == null) {
+    if(registered("location") && $hdr(X-KAZOO-PUSHER-Simultaneous-Push-and-Invite) == $null) {
        return;
     }
 


### PR DESCRIPTION
This fixes an issue so devices that remain registered after sleeping can still be woke by a push. Also, if it happens that their socket is still open, as happens for a short time during background fetch on iOS, they can answer the SIP signalling on that socket and handle the call.

Also see: https://github.com/2600hz/kazoo/pull/4033