### PR TITLE
KAZOO-5650: update tls.cfg

### DIFF
--- a/kamailio/tls.cfg
+++ b/kamailio/tls.cfg
@@ -18,8 +18,8 @@ method = SSLv23
 verify_certificate = no
 require_certificate = no
 #crl = /etc/kazoo/kamailio/certs/crl.pem
-certificate = /etc/kazoo/kamailio/certs/cert.pem
-private_key = /etc/kazoo/kamailio/certs/key.pem
+certificate = /etc/kazoo/ssl/cert.pem
+private_key = /etc/kazoo/ssl/key.pem
 #ca_list = /etc/kazoo/kamailio/certs/ca.pem
 
 # This is the default client domain, settings


### PR DESCRIPTION
We have centralized the SSL certificates to /etc/kazoo/ssl/, however the Kamailio config file for TLS still used the old paths, so that needed to be fixed.