### PR TITLE
PISTON-485: do not save/publish early dialog update if already terminated

### DIFF
--- a/kamailio/presence-role.cfg
+++ b/kamailio/presence-role.cfg
@@ -195,7 +195,7 @@ route[COUNT_PRESENTITIES]
 
 route[COUNT_PRESENTITIES_TERMINATED]
 {
-    $var(Query) = $_s(select count(*) from presentity where etag = "$(kzE{kz.json,ETag})" and event = "$(kzE{kz.json,Event-Package})");
+    $var(Query) = $_s(select count(*) from presentity where etag = "$(kzE{kz.json,Call-ID})" and event = "$(kzE{kz.json,Event-Package})");
     $var(presentities_terminated) = 0;
     if (sql_xquery("cb", "$var(Query)", "subs") == 1) {
         while($xavp(subs) != $null) {

--- a/kamailio/presence-role.cfg
+++ b/kamailio/presence-role.cfg
@@ -193,6 +193,18 @@ route[COUNT_PRESENTITIES]
     xavp_params_explode($var(p), "watchers");
 }
 
+route[COUNT_PRESENTITIES_TERMINATED]
+{
+    $var(Query) = $_s(select count(*) from presentity where etag = "$(kzE{kz.json,ETag})" and event = "$(kzE{kz.json,Event-Package})");
+    $var(presentities_terminated) = 0;
+    if (sql_xquery("cb", "$var(Query)", "subs") == 1) {
+        while($xavp(subs) != $null) {
+            $var(presentities_terminated) = $xavp(subs=>count);
+            pv_unset("$xavp(subs)");
+        }
+    }
+}
+
 route[COUNT_ALL_PRESENTITIES]
 {
     $var(Query) = $_s(select event, (select count(*) from presentity b where b.event = a.event) count from event_list a);
@@ -249,11 +261,17 @@ event_route[kazoo:consumer-event-presence-dialog-update]
 
    if($(kzE{kz.json,State}) == "terminated") {
        route(COUNT_PRESENTITIES);
+   } else if($(kzE{kz.json,State}) == "early") {
+       route(COUNT_PRESENTITIES_TERMINATED);
+       if($var(presentities_terminated) > 0) {
+           xlog("L_INFO", "$(kzE{kz.json,Call-ID})|log|not processing $(kzE{kz.json,Event-Package}) update for $(kzE{kz.json,From}) - event processed too late\n");
+           return;
+       }
    } else {
        $var(presentity) = $(kzE{kz.json,From});
        route(COUNT_SUBSCRIBERS);
    }
-   
+
    if($xavp(watchers=>dialog) > 0) {
       xlog("L_INFO", "$(kzE{kz.json,Call-ID})|log|publishing $(kzE{kz.json,From}) dialog update for $xavp(watchers=>dialog) watchers\n");
       kazoo_pua_publish_dialoginfo($var(JObj));
@@ -309,7 +327,7 @@ event_route[kazoo:consumer-event-presence-update]
 route[PRESENCE_BINDINGS]
 {
    #!import_file "presence-custom-bindings.cfg"
-    
+
    #!ifndef PRESENCE_CUSTOM_BINDINGS
    $var(payload) = "{ 'exchange' : 'presence', 'type' : 'topic', 'queue' : 'presence-dialog-MY_HOSTNAME', 'routing' : 'dialog.*.*', 'exclusive' : 0, 'federate' : 1 }";
    kazoo_subscribe("$var(payload)");
@@ -322,7 +340,7 @@ route[PRESENCE_BINDINGS]
    #!endif
 
    route(PRESENCE_RESET_BINDINGS);
-    
+
    #!ifdef PRESENCE_QUERY_ROLE
    route(PRESENCE_QUERY_BINDINGS);
    #!endif

--- a/kamailio/presence-role.cfg
+++ b/kamailio/presence-role.cfg
@@ -261,15 +261,17 @@ event_route[kazoo:consumer-event-presence-dialog-update]
 
    if($(kzE{kz.json,State}) == "terminated") {
        route(COUNT_PRESENTITIES);
-   } else if($(kzE{kz.json,State}) == "early") {
+   } else {
+       $var(presentity) = $(kzE{kz.json,From});
+       route(COUNT_SUBSCRIBERS);
+   }
+
+   if($(kzE{kz.json,State}) == "early") {
        route(COUNT_PRESENTITIES_TERMINATED);
        if($var(presentities_terminated) > 0) {
            xlog("L_INFO", "$(kzE{kz.json,Call-ID})|log|not processing $(kzE{kz.json,Event-Package}) update for $(kzE{kz.json,From}) - event processed too late\n");
            return;
        }
-   } else {
-       $var(presentity) = $(kzE{kz.json,From});
-       route(COUNT_SUBSCRIBERS);
    }
 
    if($xavp(watchers=>dialog) > 0) {


### PR DESCRIPTION
[kamailio dialog update log.txt](https://github.com/2600hz/kazoo-configs-kamailio/files/1419821/kamailio.dialog.update.log.txt)
[kamailio dialog update code snippet.txt](https://github.com/2600hz/kazoo-configs-kamailio/files/1419822/kamailio.dialog.update.code.snippet.txt)

Looking for suggestions. PR is an initial idea to solve the problem.

We've noticed an issue where a race condition between two or more Kamailio processes handling dialog updates in presence-role.cfg results in stuck BLF in the early state.

In the attached log you can see that pid 2012 and 1984 both receive a dialog update (2012 is early, 1984 is terminated). This happens when a call immediately fails, for example. What you'll notice is that 1984 gets finished first, publishing terminated and storing it in the database. Then 2012 finishes, publishing and storing the early state.

I believe that terminated events hang around for a short time **(correct me if I am wrong as the approach will have to change)**. In this tight race condition scenario we can check for terminated events matching the ETag of the early event and if we detect one or more, drop the early event.