### PR TITLE
Fixed improper behavior when on b-leg device is enabled DND feature

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -785,7 +785,7 @@ failure_route[INTERNAL_FAULT]
         xlog("L_INFO", "$ci|failure|ignoring failure after session progress\n");
     } else if (t_check_status("403") && $T_reply_reason=="Forbidden") {
         xlog("L_WARNING", "$ci|failure|Failed auth from IP $si\n");
-    } else if (t_check_status("(401)|(407)|(486)")) {
+    } else if (t_check_status("(401)|(407)|(480)|(486)")) {
         xlog("L_INFO", "$ci|failure|auth reply $T_reply_code $T_reply_reason\n");
     } else if (t_check_status("402")) {
         xlog("L_INFO", "$ci|failure|overriding reply code 402 with 486\n");


### PR DESCRIPTION
Fixed improper behavior when on b-leg device is enabled DND feature
[DND-480.pcap.gz](https://github.com/2600hz/kazoo-configs-kamailio/files/1832453/DND-480.pcap.gz)
