### PR TITLE
Update nat_uac_test flag for via re-invite issue - 4.2

### DIFF
--- a/kamailio/defs.cfg
+++ b/kamailio/defs.cfg
@@ -99,6 +99,10 @@
 #!define KZ_PRESENCE_REQUEST_PROBE 1
 #!endif
 
+#!ifndef NAT_UAC_TEST_LEVEL
+#!substdef "!NAT_UAC_TEST_LEVEL!3!g"
+#!endif
+
 #!ifndef KZ_DISABLE_WEBSOCKETS_REGISTRAR_PORT
 #!trydef KZ_WEBSOCKETS_REGISTRAR_PORT 7000
 #!endif

--- a/kamailio/local.cfg
+++ b/kamailio/local.cfg
@@ -105,6 +105,14 @@ mhomed=0
 ##!define KZ_UDP_REGISTRAR_PORT 7000
 ##!define KZ_TCP_REGISTRAR_PORT 7000
 
+################################################################################
+## NAT
+################################################################################
+## These parameters are OPTIONAL.
+##    It allows overriding the nat_uac_test with a different value than "3"
+##    (default) as it is proven that it fixes the issue reported here:
+##    https://lists.kamailio.org/pipermail/sr-users/2016-August/094211.html
+# # #!substdef "!NAT_UAC_TEST_LEVEL!1!g"
 
 ## YOU SHOULD NOT HAVE TO CHANGE THESE!
 ##     By setting MY_IP_ADDRESS above these will resolve

--- a/kamailio/nat-traversal-role.cfg
+++ b/kamailio/nat-traversal-role.cfg
@@ -32,7 +32,7 @@ route[NAT_TEST_AND_CORRECT]
         return();
     }
 
-    if (nat_uac_test("3")) {
+    if (nat_uac_test("NAT_UAC_TEST_LEVEL")) {
         force_rport();
         fix_nated_contact();
     }


### PR DESCRIPTION
This is to fixed the issue described here:

https://lists.kamailio.org/pipermail/sr-users/2016-August/094211.html

Deeper explanation here:

https://lists.kamailio.org/pipermail/sr-users/2016-August/094218.html