### PR TITLE
Update nat_uac_test flag for via re-invite issue

### DIFF
--- a/kamailio/defs.cfg
+++ b/kamailio/defs.cfg
@@ -99,6 +99,10 @@
 #!define KZ_PRESENCE_REQUEST_PROBE 1
 #!endif
 
+#!ifndef NAT_UAC_TEST_LEVEL
+#!substdef "!NAT_UAC_TEST_LEVEL!3!g"
+#!endif
+
 #################################
 ## Defs related to SIP_TRACE_ROLE
 ##

--- a/kamailio/local.cfg
+++ b/kamailio/local.cfg
@@ -106,6 +106,14 @@ mhomed=0
 ##!define KZ_UDP_REGISTRAR_PORT 7000
 ##!define KZ_TCP_REGISTRAR_PORT 7000
 
+################################################################################
+## NAT
+################################################################################
+## These parameters are OPTIONAL.
+##    It allows overriding the nat_uac_test with a different value than "3"
+##    (default) as it is proven that it fixes the issue reported here:
+##    https://lists.kamailio.org/pipermail/sr-users/2016-August/094211.html
+# # #!substdef "!NAT_UAC_TEST_LEVEL!1!g"
 
 ################################################################################
 ## SIP traffic mirroring to SIP_TRACE server

--- a/kamailio/nat-traversal-role.cfg
+++ b/kamailio/nat-traversal-role.cfg
@@ -32,7 +32,7 @@ route[NAT_TEST_AND_CORRECT]
         return();
     }
 
-    if (nat_uac_test("3")) {
+    if (nat_uac_test("NAT_UAC_TEST_LEVEL")) {
         force_rport();
         fix_nated_contact();
     }


### PR DESCRIPTION
This is to fixed the issue described here:

https://lists.kamailio.org/pipermail/sr-users/2016-August/094211.html

Deeper explanation here:

https://lists.kamailio.org/pipermail/sr-users/2016-August/094218.html