### PR TITLE
Eliminate some Kamailio warning messages, enable memory page locking

### DIFF
--- a/kamailio/registrar-role.cfg
+++ b/kamailio/registrar-role.cfg
@@ -71,8 +71,8 @@ route[HANDLE_REGISTER]
 
         ## KAZOO-1846: Cisco SPA8000 freaks out on options pings
         if (!($ua =~ "Linksys/SPA8000"
-             || $ua =~ "OpenBTS" 
-             || $ua =~ "SIPp" 
+             || $ua =~ "OpenBTS"
+             || $ua =~ "SIPp"
              || (af==INET6)
             )) {
             setbflag(FLB_NATB);
@@ -256,7 +256,7 @@ route[SAVE_LOCATION]
         }
     }
 
-    if(@contact.expires) {
+    if((int)@contact.expires) {
         $var(expires) = @contact.expires;
     } else {
         if(is_present_hf("Expires")) {
@@ -300,19 +300,19 @@ route[SAVE_LOCATION]
            $var(port) = KZ_WEBSOCKETS_REGISTRAR_PORT;
            break;
         #!endif
-            
+
         #!ifdef KZ_TLS_REGISTRAR_PORT
         case "tls":
            $var(port) = KZ_TLS_REGISTRAR_PORT;
            break;
         #!endif
-            
+
         #!ifdef KZ_UDP_REGISTRAR_PORT
         case "udp":
            $var(port) = KZ_UDP_REGISTRAR_PORT;
            break;
         #!endif
-            
+
         #!ifdef KZ_TCP_REGISTRAR_PORT
         case "tcp":
            $var(port) = KZ_UDP_REGISTRAR_PORT;
@@ -327,7 +327,7 @@ route[SAVE_LOCATION]
     if(af==INET6) {
        $var(AdvIP) = "[" + $RAi + "]";
     }
-    
+
 
     $var(amqp_payload_request) = $_s({"Event-Category" : "directory", "Event-Name" : "reg_success", "Status" : "$var(Status)", "Event-Timestamp" : $TS, "Expires" : $(var(expires){s.int}), "First-Registration" : $var(new_reg), "Contact" : "$(ct{s.escape.common}{s.replace,\','}{s.replace,$$,})", "Call-ID" : "$ci", "Realm" : "$fd", "Username" : "$fU", "From-User" : "$fU", "From-Host" : "$fd", "To-User" : "$tU", "To-Host" : "$td", "User-Agent" : "$(ua{s.escape.common}{s.replace,\','}{s.replace,$$,})" , "Custom-Channel-Vars" : $xavp(ulattrs=>custom_channel_vars), "Proxy-Path" : "sip:$var(ip):$var(port)", "Proxy-Protocol" : "$proto", "Proxy-IP" : "$var(AdvIP)", "Proxy-Port" : "$RAp", "Source-IP": "$si", "Source-Port": "$sp" });
     $var(amqp_routing_key) = "registration.success." + $(fd{kz.encode}) + "." + $(fU{kz.encode});
@@ -360,7 +360,7 @@ event_route[kazoo:consumer-event-directory-reg-flush]
        }
        reg_free_contacts("caller");
     }
-    
+
 
     #!ifdef ANTIFLOOD_ROLE
     route(ANTIFLOOD_RESET_AUTH);
@@ -370,12 +370,12 @@ event_route[kazoo:consumer-event-directory-reg-flush]
 route[REGISTRAR_BINDINGS]
 {
     #!import_file "registrar-custom-bindings.cfg"
-    
-    #!ifndef REGISTRAR_CUSTOM_BINDINGS    
+
+    #!ifndef REGISTRAR_CUSTOM_BINDINGS
 
     $var(payload) = "{ 'exchange' : 'registrar' , 'type' : 'topic', 'queue' : 'registrar-flush-MY_HOSTNAME', 'routing' : 'registration.flush.*', 'federate' : 1 }";
     kazoo_subscribe("$var(payload)");
-    
+
     #!endif
 
     #!ifdef REGISTRAR_SYNC_ROLE

--- a/system/systemd/kazoo-kamailio.service
+++ b/system/systemd/kazoo-kamailio.service
@@ -8,6 +8,7 @@ Group=daemon
 PermissionsStartOnly=true
 LimitNOFILE=65536
 LimitCORE=infinity
+LimitMEMLOCK=infinity
 ExecStartPre=/usr/sbin/kazoo-kamailio prepare
 ExecStart=/usr/sbin/kazoo-kamailio start
 ExecStop=/usr/sbin/kazoo-kamailio stop


### PR DESCRIPTION
- Add `LimitMEMLOCK=infinity` to `systemd` service file to enable locking of memory pages
- Add `(int)` cast to remove warning in `systemctl status` output