### PR TITLE
Fixed config when used database module with encryption support

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -208,6 +208,11 @@ modparam("debugger", "mod_level", "core=1")
 ####### STATISTICS ######
 loadmodule "statistics.so"
 
+####### TLS module must be loaded before database ##########
+#!ifdef TLS_ROLE
+include_file "tls-role.cfg"
+#!endif
+
 ####### DATABASE module ##########
 include_file "db_KAMAILIO_DBMS.cfg"
 
@@ -235,9 +240,6 @@ include_file "nat-traversal-role.cfg"
 #!endif
 #!ifdef WEBSOCKETS_ROLE
 include_file "websockets-role.cfg"
-#!endif
-#!ifdef TLS_ROLE
-include_file "tls-role.cfg"
 #!endif
 #!ifdef ACCOUNTING_ROLE
 include_file "accounting-role.cfg"


### PR DESCRIPTION
In my case `db_postgres` is compiled with encryption support.
In this case `tls` module must be loaded before database module.