### PR TITLE
Use primary dispatcher when associated server is not available

### DIFF
--- a/kamailio/dispatcher-role.cfg
+++ b/kamailio/dispatcher-role.cfg
@@ -158,6 +158,7 @@ route[DISPATCHER_REORDER_ROUTES]
 
         $(avp(tmp_ds_dst)[*]) = $null;
     } else {
+        ds_select_dst("$var(ds_primary_group)", "0");
         xlog("L_INFO", "$ci|log|associated media server $var(prefered_route) is inactive, moving to $rd\n");
         return -1;
     }


### PR DESCRIPTION
Side effect of the ds_select_dst call at https://github.com/2600hz/kazoo-configs-kamailio/blob/master/kamailio/dispatcher-role.cfg#L133 is that one of the backup dispatchers is selected. When the call's associated media server is not found in the primary nor the backup (e.g. it is set to inactive), this results in the fallback being a media server from the backup list. The change in this PR makes the fallback pick from the primary list instead.