### PR TITLE
Update Kamailio logrotate configuration

### DIFF
--- a/system/logrotate.d/kamailio.conf
+++ b/system/logrotate.d/kamailio.conf
@@ -1,10 +1,9 @@
 /var/log/kamailio/kamailio.log {
     daily
-    size 500M
     nodateext
     missingok
     notifempty
-    rotate 31
+    rotate 60
     maxage 5
     create
     compress


### PR DESCRIPTION
Remove 500M size check when determining whether to perform a rotation

Increase the number of archived logs from 31 to 60