### PR TITLE
registrar sync binding is using the old format and has a syntax error

### DIFF
--- a/kamailio/registrar-sync-role.cfg
+++ b/kamailio/registrar-sync-role.cfg
@@ -26,6 +26,6 @@ event_route[kazoo:consumer-event-directory-reg-sync]
 
 route[REGISTRAR_SYNC_BINDINGS]
 {
-    $var(payload) = "{ 'exchange' : 'registrar' , 'type' : 'topic', 'queue' : 'registrar-sync-MY_HOSTNAME', 'routing' : 'registration.sync' }";
+    $var(payload) =  $_s({"exchange": "registrar", "type": "topic", "queue": "registrar-sync-MY_HOSTNAME", "routing": "registration.sync"});
     kazoo_subscribe("$var(payload)");
 }


### PR DESCRIPTION
Updated the registrar sync bindings payload and correct an existing syntax error.

Master PR #111 