### PR TITLE
[4.3] Ensure $sht(auth_cache=>$Au) != 0 when comparing with authn_perm_err

### DIFF
--- a/kamailio/registrar-role.cfg
+++ b/kamailio/registrar-role.cfg
@@ -186,7 +186,9 @@ route[HANDLE_REGISTER]
     }
 
     if($sel(cfg_get.kazoo.registrar_force_query) == 0) {
-        if($sht(auth_cache=>$Au) == "authn_perm_err") {
+        if($sht(auth_cache=>$Au) != 0
+            && $sht(auth_cache=>$Au) == "authn_perm_err"
+        ) {
             xlog("L_INFO", "$ci|end|issuing auth challenge to cached permanent failed registration attempt for $Au from IP $si:$sp\n");
             update_stat("registrar:authn_perm_err", "+1");
             #!ifdef ANTIFLOOD_ROLE


### PR DESCRIPTION
When using x-token-reg in pusher to do fast reg, $var(password) is set to $null, which results in a value of 0. This value is stored in the auth_cache and leads to `rval_get_int(): automatic string to int conversion for "authn_perm_err" failed`. The fallback behaviour makes the if condition true, which isn't what is desired.