### PR TITLE
[4.3] Don't overwrite tcp_children for local listener

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -285,7 +285,7 @@ modparam("permissions", "db_url", "KAZOO_DB_URL")
 modparam("permissions", "db_mode", 1)
 
 ###### local route ######
-tcp_children = 5
+socket_workers=5
 listen=tcp:127.0.0.1:5090
 
 ####### Routing Logic ########


### PR DESCRIPTION
- Must use socket_workers instead of tcp_children for local listener so
  that the override of the tcp_children value only applies to the local
  listener