### PR TITLE
[5.0] Don't overwrite tcp_children for local listener

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -180,7 +180,7 @@ include_file "trusted.cfg"
 include_file "authorization.cfg"
 
 ###### local route ######
-tcp_children = 5
+socket_workers=5
 listen=tcp:127.0.0.1:5090
 
 ####### Routing Logic ########


### PR DESCRIPTION
- Must use socket_workers instead of tcp_children for local listener so
  that the override of the tcp_children value only applies to the local
  listener