### PR TITLE
Run CLASSIFY_SOURCE prior to FILTER_REQUEST in default.cfg

### DIFF
--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -301,6 +301,8 @@ route
     route(ANTIFLOOD_LIMIT);
     #!endif
 
+    route(CLASSIFY_SOURCE);
+
     #!ifdef TRAFFIC_FILTER_ROLE
     route(FILTER_REQUEST);
     #!endif
@@ -314,8 +316,6 @@ route
     #!endif
 
     route(LOG_REQUEST);
-
-    route(CLASSIFY_SOURCE);
 
     #!ifdef NAT_TRAVERSAL_ROLE
     route(NAT_DETECT);


### PR DESCRIPTION
Execute CLASSIFY_SOURCE route prior to FILTER_REQUEST route
FILTER_REQUEST route checks for FLAG_TRUSTED_SOURCE which only gets set in CLASSIFY_SOURCE.

This will cause INVITES from trusted IPs to be dropped, if the request domain is an IP address, which is the case with some carriers.

Also discussed in https://forums.2600hz.com/forums/topic/11601-populating-trusted-ips-for-traffic_filter_role/