### PR TITLE
Adding a new AMQP registrar search API

### DIFF
--- a/kamailio/db_queries_kazoo.cfg
+++ b/kamailio/db_queries_kazoo.cfg
@@ -12,7 +12,7 @@
 #!substdef "!KZQ_PRESENCE_SEARCH_SUMMARY!select * from active_watchers where to_domain = \"\$var(Domain)\"!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_DETAIL!select a.*, b.time, b.result, b.sent_msg, b.received_msg from active_watchers a left outer join active_watchers_log b on a.presentity_uri = b.presentity_uri and a.event = b.event and a.callid = b.callid where a.presentity_uri = \"\$var(presentity_uri)\" !g"
 
-#!substdef "!KZQ_REGISTRAR_SEARCH_SUMMARY!select contact from location where domain = \"\$var(Domain)\"!g"
+#!substdef "!KZQ_REGISTRAR_SEARCH_SUMMARY!select username,domain from location where domain = \"\$var(Domain)\"!g"
 #!substdef "!KZQ_REGISTRAR_SEARCH_DETAIL!select * from location where domain = \"\$var(Domain)\"!g"
 
 #!substdef "!KZQ_HAS_PRESENTITY!select count(*) as count from presentity where username = \"\$subs(to_user)\" and domain = \"\$subs(to_domain)\" and event = \"\$subs(event)\"!g"

--- a/kamailio/db_queries_kazoo.cfg
+++ b/kamailio/db_queries_kazoo.cfg
@@ -12,6 +12,9 @@
 #!substdef "!KZQ_PRESENCE_SEARCH_SUMMARY!select * from active_watchers where to_domain = \"\$var(Domain)\"!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_DETAIL!select a.*, b.time, b.result, b.sent_msg, b.received_msg from active_watchers a left outer join active_watchers_log b on a.presentity_uri = b.presentity_uri and a.event = b.event and a.callid = b.callid where a.presentity_uri = \"\$var(presentity_uri)\" !g"
 
+#!substdef "!KZQ_REGISTRAR_SEARCH_SUMMARY!select contact from location where domain = \"\$var(Domain)\"!g"
+#!substdef "!KZQ_REGISTRAR_SEARCH_DETAIL!select * from location where domain = \"\$var(Domain)\"!g"
+
 #!substdef "!KZQ_HAS_PRESENTITY!select count(*) as count from presentity where username = \"\$subs(to_user)\" and domain = \"\$subs(to_domain)\" and event = \"\$subs(event)\"!g"
 #!substdef "!KZQ_REPLACE_WATCHERS_LOG!REPLACE INTO active_watchers_log (presentity_uri, watcher_username, watcher_domain, event, callid, to_user, to_domain, user_agent, time, result, sent_msg, received_msg) VALUES (\"\$subs(uri)\", \"\$subs(watcher_username)\", \"\$subs(watcher_domain)\", \"\$subs(event)\",\"\$subs(callid)\",\"\$subs(to_user)\",\"\$subs(to_domain)\", '\$(subs(user_agent){s.escape.common}{s.replace,\\\',''}{s.replace,\$\$,})', \$TS, \$notify_reply(\$rs), '\$(mb{s.escape.common}{s.replace,\\\',''}{s.replace,\$\$,})', '\$(notify_reply(\$mb){s.escape.common}{s.replace,\\\',''}{s.replace,\$\$,})')!g"
 

--- a/kamailio/db_queries_mysql.cfg
+++ b/kamailio/db_queries_mysql.cfg
@@ -11,5 +11,7 @@
 #!substdef "!KZQ_RESET_PUBLISHER_UPDATE!update active_watchers set expires = \$TS where id in (select b.id from presentity a inner join active_watchers b on a.username = b.to_user and a.domain = b.to_domain and a.event = b.event where a.sender = \"\$var(MediaUrl)\")!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_DETAIL!select * from active_watchers_log where presentity_uri = \"\$var(presentity_uri)\"!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_SUMMARY!select * from active_watchers where watcher_domain = \"\$var(Domain)\"!g"
+#!substdef "!KZQ_REGISTRAR_SEARCH_SUMMARY!select contact from location where domain = \"\$var(Domain)\"!g"
+#!substdef "!KZQ_REGISTRAR_SEARCH_DETAIL!select * from location where domain = \"\$var(Domain)\"!g"
 #!substdef "!KZQ_HAS_PRESENTITY!select count(*) as count from presentity where username = \"\$subs(to_user)\" and domain = \"\$subs(to_domain)\" and event = \"\$subs(event)\"!g"
 #!substdef "!KZQ_PRESENCE_RESET!delete from presentity where sender = \"\$var(MediaUrl)\"!g"

--- a/kamailio/db_queries_mysql.cfg
+++ b/kamailio/db_queries_mysql.cfg
@@ -11,7 +11,7 @@
 #!substdef "!KZQ_RESET_PUBLISHER_UPDATE!update active_watchers set expires = \$TS where id in (select b.id from presentity a inner join active_watchers b on a.username = b.to_user and a.domain = b.to_domain and a.event = b.event where a.sender = \"\$var(MediaUrl)\")!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_DETAIL!select * from active_watchers_log where presentity_uri = \"\$var(presentity_uri)\"!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_SUMMARY!select * from active_watchers where watcher_domain = \"\$var(Domain)\"!g"
-#!substdef "!KZQ_REGISTRAR_SEARCH_SUMMARY!select contact from location where domain = \"\$var(Domain)\"!g"
+#!substdef "!KZQ_REGISTRAR_SEARCH_SUMMARY!select username,domain from location where domain = \"\$var(Domain)\"!g"
 #!substdef "!KZQ_REGISTRAR_SEARCH_DETAIL!select * from location where domain = \"\$var(Domain)\"!g"
 #!substdef "!KZQ_HAS_PRESENTITY!select count(*) as count from presentity where username = \"\$subs(to_user)\" and domain = \"\$subs(to_domain)\" and event = \"\$subs(event)\"!g"
 #!substdef "!KZQ_PRESENCE_RESET!delete from presentity where sender = \"\$var(MediaUrl)\"!g"

--- a/kamailio/db_queries_postgres.cfg
+++ b/kamailio/db_queries_postgres.cfg
@@ -11,6 +11,6 @@
 #!substdef "!KZQ_RESET_PUBLISHER_UPDATE!update active_watchers set expires = \$TS where id in (select b.id from presentity a inner join active_watchers b on a.username = b.to_user and a.domain = b.to_domain and a.event = b.event where a.sender = '\$var(MediaUrl)')!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_DETAIL!select * from active_watchers_log where presentity_uri = '\$var(presentity_uri)'!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_SUMMARY!select * from active_watchers where watcher_domain = '\$var(Domain)'!g"
-#!substdef "!KZQ_REGISTRAR_SEARCH_SUMMARY!select contact from location where domain = \"\$var(Domain)\"!g"
+#!substdef "!KZQ_REGISTRAR_SEARCH_SUMMARY!select username,domain from location where domain = \"\$var(Domain)\"!g"
 #!substdef "!KZQ_REGISTRAR_SEARCH_DETAIL!select * from location where domain = \"\$var(Domain)\"!g"
 #!substdef "!KZQ_PRESENCE_RESET!delete from presentity where sender = '\$var(MediaUrl)'!g"

--- a/kamailio/db_queries_postgres.cfg
+++ b/kamailio/db_queries_postgres.cfg
@@ -11,4 +11,6 @@
 #!substdef "!KZQ_RESET_PUBLISHER_UPDATE!update active_watchers set expires = \$TS where id in (select b.id from presentity a inner join active_watchers b on a.username = b.to_user and a.domain = b.to_domain and a.event = b.event where a.sender = '\$var(MediaUrl)')!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_DETAIL!select * from active_watchers_log where presentity_uri = '\$var(presentity_uri)'!g"
 #!substdef "!KZQ_PRESENCE_SEARCH_SUMMARY!select * from active_watchers where watcher_domain = '\$var(Domain)'!g"
+#!substdef "!KZQ_REGISTRAR_SEARCH_SUMMARY!select contact from location where domain = \"\$var(Domain)\"!g"
+#!substdef "!KZQ_REGISTRAR_SEARCH_DETAIL!select * from location where domain = \"\$var(Domain)\"!g"
 #!substdef "!KZQ_PRESENCE_RESET!delete from presentity where sender = '\$var(MediaUrl)'!g"

--- a/kamailio/registrar-query.cfg
+++ b/kamailio/registrar-query.cfg
@@ -13,7 +13,6 @@ route[REGISTRAR_SEARCH_SUMMARY]
     if($var(Username) != "") {
        $var(Query) = $var(Query) + $_s( and username = "$var(Username)");
     }
-    xlog("L_DEBUG", "$ci| QUERY $var(Query)\n");
 
     if (sql_xquery("cb", "$var(Query)", "ra") == 1)
     {
@@ -27,7 +26,6 @@ route[REGISTRAR_SEARCH_SUMMARY]
           pv_unset("$xavp(ra)");
         }
     }
-    xlog("L_DEBUG", "$ci| RESULT \"Registrations\" : { $var(Registrations) }\n");
 
     $var(amqp_payload_request) = $_s({"Event-Category" : "registration", "Event-Name" : "search_resp", "Msg-ID" : "$(kzE{kz.json,Msg-ID})", "Registrations" : [ $var(Registrations) ] });
     kazoo_publish("targeted", "$var(Queue)", $var(amqp_payload_request));
@@ -45,21 +43,19 @@ route[REGISTRAR_SEARCH_DETAIL]
     if($var(Username) != "") {
        $var(Query) = $var(Query) + $_s( and username = "$var(Username)");
     }
-    xlog("L_DEBUG", "$ci| STATUS QUERY $var(Query)\n");
 
     if (sql_xquery("cb", "$var(Query)", "ra") == 1)
     {
         while($xavp(ra) != $null) {
-          $var(Registration) = $_s({"Contact":"$(xavp(ra=>contact))", "Received":"$(xavp(ra=>received))", "Path":"$(xavp(ra=>path))", "Expires":"$(xavp(ra=>expires))", "Call-ID":"$(xavp(ra=>callid))", "CSeq":"$(xavp(ra=>cseq))", "Last-Modified":"$(xavp(ra=>last_modified))", "User-Agent":"$(xavp(ra=>user_agent))", "Socket":"$(xavp(ra=>socket))"});
+          $var(Registration) = $_s({"Contact":"$(xavp(ra=>contact))", "Received":"$(xavp(ra=>received))", "Path":"$(xavp(ra=>path))", "Expires":$(xavp(ra=>expires)), "Call-ID":"$(xavp(ra=>callid))", "CSeq":"$(xavp(ra=>cseq))", "Last-Modified":"$(xavp(ra=>last_modified))", "User-Agent":"$(xavp(ra=>user_agent){s.escape.common}{s.replace,\','}{s.replace,$$,})", "Socket":"$(xavp(ra=>socket))"});
           pv_unset("$xavp(ra)");
-          xlog("L_DEBUG", "$ci| RESULT \"Registrations\" : { $var(Registration) }\n");
 
           $var(amqp_payload_request) = '{"Event-Category" : "registration", "Event-Name" : "search_partial_resp", "Msg-ID" : "$var(Msg-ID)", "Registrations" : [ $var(Registration) ] }';
           kazoo_publish("targeted", "$var(Queue)", $var(amqp_payload_request));
         }
     }
 
-    $var(amqp_payload_request) = '{"Event-Category" : "registration", "Event-Name" : "search_resp", "Msg-ID" : "$var(Msg-ID)" }';
+    $var(amqp_payload_request) = '{"Event-Category" : "registration", "Event-Name" : "search_resp", "Msg-ID" : "$var(Msg-ID)", "Registrations":[] }';
     kazoo_publish("targeted", "$var(Queue)", $var(amqp_payload_request));
 
 }

--- a/kamailio/registrar-query.cfg
+++ b/kamailio/registrar-query.cfg
@@ -1,0 +1,89 @@
+######## Registrar query server module ########
+
+#!trydef KZ_REGISTRAR_QUERY_REPLY_ZONES 0
+kazoo.registrar_query_reply_zones = KZ_REGISTRAR_QUERY_REPLY_ZONES descr "0 - all, 1 - local, 2 - remote"
+
+route[REGISTRAR_SEARCH_SUMMARY]
+{
+    xlog("L_INFO", "$(kzE{kz.json,Msg-ID})|query|processing registrar summary query for $(kzE{kz.json,Realm})\n");
+    $var(Queue) = $(kzE{kz.json,Server-ID});
+    $var(Domain) = $(kzE{kz.json,Realm});
+    $var(Username) = $(kzE{kz.json,Username});
+    $var(Query) = $_s(KZQ_REGISTRAR_SEARCH_SUMMARY);
+    if($var(Username) != "") {
+       $var(Query) = $var(Query) + $_s( and username = "$var(Username)");
+    }
+    xlog("L_DEBUG", "$ci| QUERY $var(Query)\n");
+
+    if (sql_xquery("cb", "$var(Query)", "ra") == 1)
+    {
+        $var(Registrations) = "";
+        $var(Sep1) = "";
+        while($xavp(ra) != $null) {
+          $var(Contact) = $(xavp(ra=>contact));
+
+          $var(Registrations) = $var(Registrations) + $var(Sep1) + $_s("$var(Contact)");
+          $var(Sep1)=", ";
+
+          pv_unset("$xavp(ra)");
+        }
+    }
+    xlog("L_DEBUG", "$ci| RESULT \"Registrations\" : { $var(Registrations) }\n");
+
+    $var(amqp_payload_request) = $_s({"Event-Category" : "directory", "Event-Name" : "search_resp", "Msg-ID" : "$(kzE{kz.json,Msg-ID})", "Registrations" : [ $var(Registrations) ] });
+    kazoo_publish("targeted", "$var(Queue)", $var(amqp_payload_request));
+
+}
+
+route[PRESENCE_SEARCH_DETAIL]
+{
+    xlog("L_INFO", "$(kzE{kz.json,Msg-ID})|query|processing presence query detail for $(kzE{kz.json,Username}) in realm $(kzE{kz.json,Realm})\n");
+    $var(Queue) = $(kzE{kz.json,Server-ID});
+    $var(Msg-ID) = $(kzE{kz.json,Msg-ID});
+    $var(Domain) = $(kzE{kz.json,Realm});
+    $var(Username) = $(kzE{kz.json,Username});
+    $var(Query) = $_s(KZQ_REGISTRAR_SEARCH_DETAIL);
+    if($var(Username) != "") {
+       $var(Query) = $var(Query) + $_s( and username = "$var(Username)");
+    }
+    xlog("L_DEBUG", "$ci| STATUS QUERY $var(Query)\n");
+
+    if (sql_xquery("cb", "$var(Query)", "ra") == 1)
+    {
+        $var(Registrations) = "";
+        $var(Sep1) = "";
+        while($xavp(ra) != $null) {
+          $var(Registration) = $_s({"Contact":"$(xavp(ra=>contact))", "Received":"$(xavp(ra=>received))", "Path":"$(xavp(ra=>path))", "Expires":"$(xavp(ra=>expires))", "Call-ID":"$(xavp(ra=>callid))", "CSeq":"$(xavp(ra=>cseq))", "Last-Modified":"$(xavp(ra=>last_modified))", "User-Agent":"$(xavp(ra=>user_agent))", "Socket":"$(xavp(ra=>socket))", "proxy":"kamailio@MY_HOSTNAME"});
+          pv_unset("$xavp(ra)");
+          xlog("L_DEBUG", "$ci| RESULT \"Registrations\" : { $var(Registration) }\n");
+
+          $var(amqp_payload_request) = '{"Event-Category" : "directory", "Event-Name" : "search_partial_resp", "Msg-ID" : "$var(Msg-ID)", "Registrations" : $var(Registration) }';
+          kazoo_publish("targeted", "$var(Queue)", $var(amqp_payload_request));
+        }
+    }
+
+    $var(amqp_payload_request) = '{"Event-Category" : "directory", "Event-Name" : "search_resp", "Msg-ID" : "$var(Msg-ID)" }';
+    kazoo_publish("targeted", "$var(Queue)", $var(amqp_payload_request));
+
+}
+
+event_route[kazoo:consumer-event-registrar-search-req]
+{
+  $var(Zone) = $(kzE{kz.json,AMQP-Broker-Zone});
+  if( ($var(Zone) == "MY_AMQP_ZONE" && $sel(cfg_get.kazoo.registrar_query_reply_zones) != 2) ||
+      ($var(Zone) != "MY_AMQP_ZONE" && $sel(cfg_get.kazoo.registrar_query_reply_zones) != 1)) {
+
+      switch($(kzE{kz.json,Search-Type})) {
+        case "summary":
+            route(REGISTRAR_SEARCH_SUMMARY);
+            break;
+        case "detail":
+            route(REGISTRAR_SEARCH_DETAIL);
+            break;
+        default:
+            xlog("L_INFO", "$ci|search type '$(kzE{kz.json,Search-Type})' not handled\n");
+      }
+  }
+}
+
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab

--- a/kamailio/registrar-query.cfg
+++ b/kamailio/registrar-query.cfg
@@ -20,9 +20,8 @@ route[REGISTRAR_SEARCH_SUMMARY]
         $var(Registrations) = "";
         $var(Sep1) = "";
         while($xavp(ra) != $null) {
-          $var(Contact) = $(xavp(ra=>contact));
-
-          $var(Registrations) = $var(Registrations) + $var(Sep1) + $_s("$var(Contact)");
+          $var(Registration) = $_s("$(xavp(ra=>username))@$(xavp(ra=>domain))");
+          $var(Registrations) = $var(Registrations) + $var(Sep1) + $var(Registration);
           $var(Sep1)=", ";
 
           pv_unset("$xavp(ra)");
@@ -30,14 +29,14 @@ route[REGISTRAR_SEARCH_SUMMARY]
     }
     xlog("L_DEBUG", "$ci| RESULT \"Registrations\" : { $var(Registrations) }\n");
 
-    $var(amqp_payload_request) = $_s({"Event-Category" : "directory", "Event-Name" : "search_resp", "Msg-ID" : "$(kzE{kz.json,Msg-ID})", "Registrations" : [ $var(Registrations) ] });
+    $var(amqp_payload_request) = $_s({"Event-Category" : "registration", "Event-Name" : "search_resp", "Msg-ID" : "$(kzE{kz.json,Msg-ID})", "Registrations" : [ $var(Registrations) ] });
     kazoo_publish("targeted", "$var(Queue)", $var(amqp_payload_request));
 
 }
 
-route[PRESENCE_SEARCH_DETAIL]
+route[REGISTRAR_SEARCH_DETAIL]
 {
-    xlog("L_INFO", "$(kzE{kz.json,Msg-ID})|query|processing presence query detail for $(kzE{kz.json,Username}) in realm $(kzE{kz.json,Realm})\n");
+    xlog("L_INFO", "$(kzE{kz.json,Msg-ID})|query|processing registrar query detail for $(kzE{kz.json,Username}) in realm $(kzE{kz.json,Realm})\n");
     $var(Queue) = $(kzE{kz.json,Server-ID});
     $var(Msg-ID) = $(kzE{kz.json,Msg-ID});
     $var(Domain) = $(kzE{kz.json,Realm});
@@ -50,24 +49,22 @@ route[PRESENCE_SEARCH_DETAIL]
 
     if (sql_xquery("cb", "$var(Query)", "ra") == 1)
     {
-        $var(Registrations) = "";
-        $var(Sep1) = "";
         while($xavp(ra) != $null) {
-          $var(Registration) = $_s({"Contact":"$(xavp(ra=>contact))", "Received":"$(xavp(ra=>received))", "Path":"$(xavp(ra=>path))", "Expires":"$(xavp(ra=>expires))", "Call-ID":"$(xavp(ra=>callid))", "CSeq":"$(xavp(ra=>cseq))", "Last-Modified":"$(xavp(ra=>last_modified))", "User-Agent":"$(xavp(ra=>user_agent))", "Socket":"$(xavp(ra=>socket))", "proxy":"kamailio@MY_HOSTNAME"});
+          $var(Registration) = $_s({"Contact":"$(xavp(ra=>contact))", "Received":"$(xavp(ra=>received))", "Path":"$(xavp(ra=>path))", "Expires":"$(xavp(ra=>expires))", "Call-ID":"$(xavp(ra=>callid))", "CSeq":"$(xavp(ra=>cseq))", "Last-Modified":"$(xavp(ra=>last_modified))", "User-Agent":"$(xavp(ra=>user_agent))", "Socket":"$(xavp(ra=>socket))"});
           pv_unset("$xavp(ra)");
           xlog("L_DEBUG", "$ci| RESULT \"Registrations\" : { $var(Registration) }\n");
 
-          $var(amqp_payload_request) = '{"Event-Category" : "directory", "Event-Name" : "search_partial_resp", "Msg-ID" : "$var(Msg-ID)", "Registrations" : $var(Registration) }';
+          $var(amqp_payload_request) = '{"Event-Category" : "registration", "Event-Name" : "search_partial_resp", "Msg-ID" : "$var(Msg-ID)", "Registrations" : [ $var(Registration) ] }';
           kazoo_publish("targeted", "$var(Queue)", $var(amqp_payload_request));
         }
     }
 
-    $var(amqp_payload_request) = '{"Event-Category" : "directory", "Event-Name" : "search_resp", "Msg-ID" : "$var(Msg-ID)" }';
+    $var(amqp_payload_request) = '{"Event-Category" : "registration", "Event-Name" : "search_resp", "Msg-ID" : "$var(Msg-ID)" }';
     kazoo_publish("targeted", "$var(Queue)", $var(amqp_payload_request));
 
 }
 
-event_route[kazoo:consumer-event-registrar-search-req]
+event_route[kazoo:consumer-event-registration-search-req]
 {
   $var(Zone) = $(kzE{kz.json,AMQP-Broker-Zone});
   if( ($var(Zone) == "MY_AMQP_ZONE" && $sel(cfg_get.kazoo.registrar_query_reply_zones) != 2) ||

--- a/kamailio/registrar-role.cfg
+++ b/kamailio/registrar-role.cfg
@@ -500,9 +500,22 @@ route[REGISTRAR_BINDINGS]
 
     #!endif
 
+    route(REGISTRAR_API_BINDINGS);
+
     #!ifdef REGISTRAR_SYNC_ROLE
     route(REGISTRAR_SYNC_BINDINGS);
     #!endif
+
+}
+
+route[REGISTRAR_API_BINDINGS]
+{
+   #!import_file "registrar-api-custom-bindings.cfg"
+
+   #!ifndef REGISTRAR_API_CUSTOM_BINDINGS
+   $var(payload) = $_s({"name": "registrar-api", "exchange": "registrar", "type": "topic", "queue": "registrar-api-MY_HOSTNAME", "routing": ["directory.search_req.*"], "exclusive": false, "federate": true });
+   kazoo_subscribe("$var(payload)");
+   #!endif
 
 }
 

--- a/kamailio/registrar-role.cfg
+++ b/kamailio/registrar-role.cfg
@@ -146,6 +146,8 @@ kazoo.registrar_keepalive_udp_only = KZ_REGISTRAR_KEEPALIVE_UDP_ONLY descr "shou
 kazoo.registrar_send_100 = REGISTRAR_SEND_100 descr "should we send 100 reply while doing directory search"
 kazoo.registrar_publish_reg_once = KZ_REGISTRAR_PUBLISH_REG_ONCE descr "should publish only new registrations"
 
+#!include_file "registrar-query.cfg"
+
 ####### Registrar Logic ########
 
 route[REGISTRAR_NAT_FLAGS]
@@ -513,7 +515,7 @@ route[REGISTRAR_API_BINDINGS]
    #!import_file "registrar-api-custom-bindings.cfg"
 
    #!ifndef REGISTRAR_API_CUSTOM_BINDINGS
-   $var(payload) = $_s({"name": "registrar-api", "exchange": "registrar", "type": "topic", "queue": "registrar-api-MY_HOSTNAME", "routing": ["directory.search_req.*"], "exclusive": false, "federate": true });
+   $var(payload) = $_s({"name": "registrar-api", "exchange": "registrar", "type": "topic", "queue": "registrar-api-MY_HOSTNAME", "routing": ["registration.search_req.*"], "exclusive": false, "federate": true });
    kazoo_subscribe("$var(payload)");
    #!endif
 


### PR DESCRIPTION
Sending the following search request to the registrar exchange with a routing key: registrations.search_req.{account-sip-realm}
```
{
  "Event-Category": "registration",
  "Event-Name": "search_req",
  "Search-Type": "summary",
  "Server-ID": "{search-reply-queue}",
  "Realm": "{account-sip-realm}",
  "Msg-ID": "{search-request-id}",
  "Call-ID": "{uuid}",
  "AMQP-Broker-Zone": "{zone-name}"
}
```

will result in all kamailio servers publishing a reply such as:

```
{
  "App-Name": "kamailio",
  "App-Version": "5.4.1",
  "Event-Category": "registration",
  "Event-Name": "search_resp",
  "Msg-ID": "search-request-id",
  "Node": "kamailio@apps001.ewr.sb.2600hz.com",
  "Registrations": [
    "user_1@account-sip-realm",
    "user_2@account-sip-realm",
    "user_4@account-sip-realm",
    "user_5@account-sip-realm",
    "user_6@account-sip-realm"
  ]
}
```

If there is no currently valid registration the username@realm will not be present in the list (note example user_3 above).

If the Search-Type of the search_req message is "detail" the Server-ID queue will receive one message per current valid registration belonging to the account, such as:

```
{
  "App-Name": "kamailio",
  "App-Version": "5.4.1",
  "Event-Category": "registration",
  "Event-Name": "search_partial_resp",
  "Msg-ID": "{search-request-id}",
  "Node": "kamailio@apps001.ewr.sb.2600hz.com",
  "Registrations": [
    {
      "CSeq": "30",
      "Call-ID": "102649NzFjZjRhMzVkNWY4NmYxYzAxNzBhMTM1NDFmZGUzYTM",
      "Contact": "sip:user_1@162.123.321.146:63287;rinstance=62d2bf448b457fe6",
      "Expires": "1604354290",
      "Last-Modified": "1604353929",
      "Path": "<null>",
      "Received": "sip:162.123.321.146:63287",
      "Socket": "udp:124.247.144.98:5060",
      "User-Agent": "Bria 5 release 5.8.3 stamp 102649"
    }
  ]
}
```

until a partial search response has been sent for each valid registration, then the request terminated with the message:

```
{
  "App-Name": "kamailio",
  "App-Version": "5.4.1",
  "Event-Category": "registration",
  "Event-Name": "search_resp",
  "Msg-ID": "search-request-id",
  "Node": "kamailio@apps001.ewr.sb.2600hz.com"
}
```


Optionally the search_req can specify a username, which if provided will return an empty Registations list from each kamailio if not currently registered in the cluster, or one of the kamailio replies will contain the record in either the summary or detail format depending on the request.
