### PR TITLE
[5.1] KAM26-25: set `Referred-By` params from authz

### DIFF
--- a/kamailio/authorization.cfg
+++ b/kamailio/authorization.cfg
@@ -74,6 +74,10 @@ route[AUTHORIZATION_CHECK]
 {
     route(KZ_AUTHORIZATION_SETUP);
     routes(AUTHORIZATION_CHECK);
+
+    if (isflagset(FLAG_REGISTERED_ENDPOINT)) {
+        route(AUTHORIZATION_SET_AUTHZ);
+    }
 }
 
 route[AUTHORIZATION_CHECK_TRUSTED]
@@ -85,6 +89,13 @@ route[AUTHORIZATION_CHECK_TRUSTED]
         route(SETUP_AUTH_TRUSTED);
         setflag(FLAG_AUTHORIZED);
     }
+}
+
+route[AUTHORIZATION_SET_AUTHZ]
+{
+    $xavp(authz=>token) = $xavp(ulattrs=>token);
+    $xavp(authz[0]=>endpoint_id) = $(xavp(ulattrs=>token){re.subst,/(.*)@(.*)/\1/});
+    $xavp(authz[0]=>account_id) = $(xavp(ulattrs=>token){re.subst,/(.*)@(.*)/\2/});
 }
 
 route[HANDLE_AUTHORIZATION_KAZOO]
@@ -170,6 +181,8 @@ route[KZ_AUTHORIZATION_CHECK_RESPONSE]
     $xavp(hf[0]=>X-AUTH-Token) = $xavp(authz=>token);
 
     setflag(FLAG_AUTHORIZED);
+    # treat req as if it was from a reg'd endpoint despite absent location record
+    setflag(FLAG_REGISTERED_ENDPOINT);
 
     # flag that contact alias needs to be added for subscribe
     setflag(FLAG_MANUAL_ALIAS);

--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -421,7 +421,7 @@ route[HANDLE_REFER]
 
     if(!isflagset(FLAG_INTERNALLY_SOURCED)) {
         if(isflagset(FLAG_REGISTERED_ENDPOINT)) {
-            $var(referred_by) = $_s($var(referred_by);endpoint_id=$(xavp(ulattrs=>token){re.subst,/(.*)@(.*)/\1/});account_id=$(xavp(ulattrs=>token){re.subst,/(.*)@(.*)/\2/}));
+            $var(referred_by) = $_s($var(referred_by);endpoint_id=$xavp(authz=>endpoint_id));
         }
         routes(HANDLE_EXTERNAL_REFER);
         append_hf("Referred-By: $var(referred_by)\r\n");

--- a/kamailio/registrar-role.cfg
+++ b/kamailio/registrar-role.cfg
@@ -425,7 +425,7 @@ route[SAVE_LOCATION]
        $var(AdvIP) = "[" + $RAi + "]";
     }
 
-    route(REGISTRAR_SET_AUTHZ);
+    route(AUTHORIZATION_SET_AUTHZ);
     route(PUBLISH_REGISTRATION);
     routes(ON_REGISTRATION);
 
@@ -815,15 +815,7 @@ route[AUTHORIZATION_CHECK_REGISTERED]
         $xavp(hf[0]=>X-AUTH-Token) = $xavp(ulattrs=>token);
         setflag(FLAG_AUTHORIZED);
         setflag(FLAG_REGISTERED_ENDPOINT);
-        route(REGISTRAR_SET_AUTHZ);
     }
-}
-
-route[REGISTRAR_SET_AUTHZ]
-{
-    $xavp(authz=>token) = $xavp(ulattrs=>token);
-    $xavp(authz[0]=>endpoint_id) = $(xavp(ulattrs=>token){re.subst,/(.*)@(.*)/\1/});
-    $xavp(authz[0]=>account_id) = $(xavp(ulattrs=>token){re.subst,/(.*)@(.*)/\2/});
 }
 
 # vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab


### PR DESCRIPTION
Backport of #155

When `REFER` is challenged and authz'd by Kazoo via AMQP, treat the req as if it were a registered endpoint.

Centralize setting of $xavp(authz) at end of `AUTHORIZATION_CHECK`.