### PR TITLE
KAM26-28 Send Token-Public-Proxy in wake up push to mobile app

### DIFF
--- a/kamailio/push-notifications-role.cfg
+++ b/kamailio/push-notifications-role.cfg
@@ -142,14 +142,18 @@ route[PN_SEND_PUSH_NOTIFICATION]
 }
 
 route[NEWCALL_PUSH] {
-    xlog("L_INFO", "$ci: sending new call notification push for $hdr(X-KAZOO-AOR)");
+    $var(TokenProxy) = $hdr(X-KAZOO-PUSHER-Token-Public-Proxy);
+    #!ifdef PUSHER_TOKEN_PROXY
+    $var(TokenProxy) = $_s(PUSHER_TOKEN_PROXY);
+    #!endif
+    xlog("L_INFO", "$ci: sending new call notification push for $hdr(X-KAZOO-AOR) via token proxy $var(TokenProxy)");
     $var(fn) = $(fn{s.replace,",});
     if (is_present_hf("Alert-Info")) {
         $var(ring_tone) = $_s(, "ring_tone":"$hdr(Alert-Info)");
     } else {
         $var(ring_tone) = "";
     }
-    $var(payload) = '{"name":"'+$hdr(X-KAZOO-AOR)+'", "app_name":"PUSH_NOTIFICATIONS_APP_NAME", "expiry":20, "type":"incoming_call", "silent":true, "payload":{"remote_name":"'+$var(fn)+'", "remote_number":"'+$fU+'", "local_number":"'+$hdr(X-KAZOO-AOR)+'", "inception_number":"'+$hdr(X-ooma-inception-number)+'", "push_id":"'+$ci+'"' +$var(ring_tone)+ '}}';
+    $var(payload) = '{"name":"'+$hdr(X-KAZOO-AOR)+'", "app_name":"PUSH_NOTIFICATIONS_APP_NAME", "expiry":20, "type":"incoming_call", "silent":true, "payload":{"remote_name":"'+$var(fn)+'", "remote_number":"'+$fU+'", "local_number":"'+$hdr(X-KAZOO-AOR)+'", "inception_number":"'+$hdr(X-ooma-inception-number)+'", "token_proxy":"'+$var(TokenProxy)+'", "push_id":"'+$ci+'"' +$var(ring_tone)+ '}}';
     $var(response) = http_connect("pushsrv", "/api/v1/send", "application/json", $var(payload), "$avp(result)");        
     if ($var(response) != 200) {
         xlog("L_ERR","$ci: Failed to send push for $hdr(X-KAZOO-AOR). response: $var(response)");


### PR DESCRIPTION
Need to send token_proxy public uri in wake up push to mobile app in order to support registration on multiple kams. The same logic exists in pusher-role.cfg.