### PR TITLE
KAM26-29 Disabled SSL older than TLS1.2

### DIFF
--- a/kamailio/tls.cfg
+++ b/kamailio/tls.cfg
@@ -14,7 +14,7 @@
 # to present client certificates by default.
 #
 [server:default]
-method = SSLv23
+method = TLSv1.2+
 verify_certificate = no
 require_certificate = no
 #crl = /etc/kazoo/kamailio/certs/crl.pem


### PR DESCRIPTION
Update tls.cfg to disable all SSL methods older than TLS1.2.