### PR TITLE
KAM26-42 : Update Kazoo Kamailio Configs to Validate Privacy Headers

### DIFF
--- a/kamailio/authorization.cfg
+++ b/kamailio/authorization.cfg
@@ -264,8 +264,12 @@ route[SETUP_AUTH_TRUSTED]
             $xavp(hf[0]=>X-AUTH-From-User) = $(ai{uri.user});
         } else if(is_present_hf("P-Preferred-Identity") && $pU != "") {
             $xavp(hf[0]=>X-AUTH-From-User) = $pU;
-        } else if(is_present_hf("Remote-Party-ID") && $(re{uri.user}) != "") {
-            $xavp(hf[0]=>X-AUTH-From-User) = $(re{uri.user});
+        } else if(is_present_hf("Remote-Party-ID")) {
+            if ($(hdr(Remote-Party-ID){param.value,privacy}) != "" && $(hdr(Remote-Party-ID){param.value,privacy}) != "off") {
+                $xavp(hf[0]=>X-AUTH-From-User) = "anonymous";
+            } else if ($(re{uri.user}) != "") {
+                $xavp(hf[0]=>X-AUTH-From-User) = $(re{uri.user});
+            }
         } else {
             $xavp(hf[0]=>X-AUTH-From-User) = $fU;
         }


### PR DESCRIPTION
Previously, the `privacy` tag in the `Remote-Party-ID` header was not considered when determining whether to treat a call as anonymous. Now, the `privacy` tag is checked, and if it is not set to off, the `X-AUTH-From-User` header is appropriately set to anonymous and the call will be treated as anonymous.