### PR TITLE
Pre-save registration hook

### DIFF
--- a/kamailio/registrar-role.cfg
+++ b/kamailio/registrar-role.cfg
@@ -377,7 +377,8 @@ route[UPDATE_LOCATION]
 
 route[SAVE_LOCATION]
 {
-
+    routes(REGISTRAR_PRE_SAVE_LOCATION);
+    
     if ($sht(auth_cache=>$avp(auth-uri)) == $null && $vn(password) != $null) {
         xlog("L_INFO", "caching sip credentials for $avp(auth-uri)\n");
     };


### PR DESCRIPTION
A hook allowing to perform actions before new registration record is saved to location DB

needed for https://github.com/2600hz/kazoo-configs-kamailio-extras/pull/9