### PR TITLE
KECA-53: Suport NWAY calling as default 2600Hz Kazoo product

### DIFF
--- a/kamailio/conference-factory-role.cfg
+++ b/kamailio/conference-factory-role.cfg
@@ -1,0 +1,132 @@
+## conference factory role
+## handles 3way conferences server side
+##
+## depends on
+##   media-duid.cfg
+##   conference-factory-cisco-sdp
+##
+## dialplan.d
+##   conference-factory.json
+##
+## 
+
+route[EXTERNAL_TO_INTERNAL_RELAY_CONFERENCE_FACTORY_INVITE]
+{
+    if (!is_method("INVITE")) return;
+    if (!is_request()) return;
+    if (!isflagset(FLAG_REGISTERED_ENDPOINT)) return;
+    if ($rU != "conference-factory") return;
+
+
+    xlog("L_DEBUG", "DU => $du\n");
+    $var(conference-media-id) = "";
+    if (ds_is_from_list(-1, 2, "$du")) {
+        $var(conference-media-id) = "+" + $(var(ds_attrs){param.value,duid});
+        xlog("L_DEBUG", "DU => $du , $var(ds_attrs) , $(var(ds_attrs){param.value,duid}) , $var(conference-media-id)\n");
+    }
+
+    $var(conference-id) = $uuid(g);
+
+    $tU = "conference-factory+" + $var(conference-id) + $var(conference-media-id);
+    append_hf("X-FS-Endpoint-Dialplan: conference-factory@features.invalid\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-ID: $var(conference-id)\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-Flags: endconf\r\n");
+
+    xlog("L_INFO", "added dialplan conference-factory@features.invalid with conference id $var(conference-id) to invite\n"); 
+}
+
+
+# this is only used if we use X-Redirect-Server when handling the REFER
+route[EXTERNAL_TO_INTERNAL_RELAY_CONFERENCE_FACTORY_INVITE_REFER]
+{
+    if (!is_method("INVITE")) return;
+    if (!is_request()) return;
+    if (!($rU =~ "conference-factory\+")) return;
+
+    $var(conference-id) = $(rU{s.after,+}{s.before,+});
+    $var(conference-media-id) = $(rU{s.after,+}{s.after,+});
+
+    # $du should already be set
+
+    xlog("L_DEBUG", "DU => $du, conf => $var(conference-media-id)\n");
+    xlog("L_DEBUG", "DU => $du, conf => $sht(duid=>$var(conference-media-id))\n");
+
+    append_hf("X-FS-Endpoint-Dialplan: conference-factory@features.invalid\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-ID: $var(conference-id)\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-Flags: join-only\r\n");
+
+    xlog("L_INFO", "added dialplan conference-factory@features.invalid with conference id $var(conference-id) to invite\n"); 
+
+}
+
+route[EXTERNAL_TO_INTERNAL_RELAY_CONFERENCE_FACTORY_REFER]
+{
+    if (!is_method("REFER")) return;
+    if (!is_request()) return;
+    if (!isflagset(FLAG_REGISTERED_ENDPOINT)) return;
+    if (!($(rt{uri.user}) =~ "conference-factory\+")) return;
+
+    $var(conference-id) = $(rt{uri.user}{s.after,+}{s.before,+});
+    $var(conference-media-id) = $(rt{uri.user}{s.after,+}{s.after,+});
+
+    xlog("L_DEBUG", "conference-id => $var(conference-id), conference-media-id => $var(conference-media-id)\n");
+    xlog("L_DEBUG", "DU => $du, refer-to-user => $(rt{uri.user}), refer-to => $rt\n");
+
+    $var(call-media-id) = "";
+    if (ds_is_from_list(-1, 2, "$du")) {
+        $var(call-media-id) = $(var(ds_attrs){param.value,duid});
+    }
+
+    xlog("L_DEBUG", "DU => $du, conf => $var(conference-media-id) , call => $var(call-media-id)\n");
+    xlog("L_DEBUG", "DU => $du, conf => $sht(duid=>$var(conference-media-id)) , call => $sht(duid=>$var(call-media-id))\n");
+
+    append_hf("X-FS-Endpoint-Dialplan: conference-factory@features.invalid\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-ID: $var(conference-id)\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-Flags: join-only\r\n");
+
+    # redirect server
+    # REFER goes to freeswitch that sees X-Redirect-Server and does a deflect (REFER) back to A-leg
+    # which will then send a BYE and a new INVITE to the refer-to
+    # because we handle REFER from internal and do an association with X-Redirect-Server
+    # the INVITE gets routed to the correct media server
+    #
+    # this works only if endpoints are devices
+    # carriers usually don't support REFER
+    #
+    # if ($var(conference-media-id) != $var(call-media-id)) {
+    #     xlog("L_INFO", "adding Conference-Host => $(sht(duid=>$var(conference-media-id)){uri.host})\n");
+    #     append_hf("X-Redirect-Server: $sht(duid=>$var(conference-media-id))\r\n");
+    # }
+    #
+
+
+    # one alternative is to use different dialplans
+    # normal behaviour or
+    # cross server bridge into remote conference
+    # as we do with conferences app
+    # need to comment the above X-FS-Endpoint-Dialplan
+    # if ($var(conference-media-id) != $var(call-media-id)) {
+    #     append_hf("X-FS-Endpoint-Dialplan: conference-factory-remote@features.invalid\r\n");
+    # } else {
+    #     append_hf("X-FS-Endpoint-Dialplan: conference-factory-local@features.invalid\r\n");
+    # }
+
+    # another alternative is to change the dialplan
+    # so it handles a parameter that will indicate
+    # to do cross server bridge into remote conference
+    # as we do with conferences app
+    if ($var(conference-media-id) != "") {
+        if ($var(call-media-id) != "") {
+            if($var(conference-media-id) != $var(call-media-id)) {
+                $var(conference-host) = $sht(duid=>$var(conference-media-id));
+                append_hf("X-FS-Endpoint-Dialplan-Conference-URI-Host: $var(conference-host)\r\n");
+                append_hf("X-FS-Endpoint-Dialplan-Conference-Host: $(var(conference-host){uri.host})\r\n");
+            }
+        }
+    }
+
+    xlog("L_INFO", "added dialplan conference-factory@features.invalid with conference id $var(conference-id) to refer\n"); 
+
+}
+
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab

--- a/kamailio/conference-factory-role.cfg
+++ b/kamailio/conference-factory-role.cfg
@@ -1,0 +1,167 @@
+## conference factory role
+## handles 3way conferences server side
+##
+## depends on
+##   kazoo-conference
+##     priv/couchdb/sys_config/dialplan.features.conference_factory.json
+##
+
+## maintains conference_duid hash table for media node lookups
+modparam("htable", "htable", "conference_duid=>size=8");
+
+route[CONFERENCE_FACTORY_LOAD_DUID]
+{
+    sht_reset("conference_duid");
+    xlog("L_INFO", "initializing conference_duid hash table from dispatcher\n");
+    if (sql_xquery("exec", "select destination, attrs from dispatcher", "ra") == 1) {
+        while($xavp(ra) != $null) {
+            $sht(conference_duid=>$(xavp(ra=>attrs){param.value,duid})) = $xavp(ra=>destination);
+            pv_unset("$xavp(ra)");
+        }
+    }
+}
+
+route[KZ_DEFERRED_INIT_CONFERENCE_FACTORY]
+{
+    route(CONFERENCE_FACTORY_LOAD_DUID);
+}
+
+route[DISPATCHER_RELOADED_CONFERENCE_FACTORY]
+{
+    route(CONFERENCE_FACTORY_LOAD_DUID);
+}
+
+route[EXTERNAL_TO_INTERNAL_RELAY_CONFERENCE_FACTORY_INVITE]
+{
+    if (!is_method("INVITE")) return;
+    if (!is_request()) return;
+    if (!isflagset(FLAG_REGISTERED_ENDPOINT)) return;
+    if ($rU != "conference-factory") return;
+
+
+    xlog("L_DEBUG", "DU => $du\n");
+    $var(conference-media-id) = "";
+    if (ds_is_from_list(-1, 2, "$du")) {
+        $var(conference-media-id) = "+" + $(var(ds_attrs){param.value,duid});
+        xlog("L_DEBUG", "DU => $du , $var(ds_attrs) , $(var(ds_attrs){param.value,duid}) , $var(conference-media-id)\n");
+    }
+
+    $var(conference-id) = $uuid(g);
+
+    $tU = "conference-factory+" + $var(conference-id) + $var(conference-media-id);
+    append_hf("X-FS-Endpoint-Dialplan: conference-factory@features.invalid\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-ID: $var(conference-id)\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-Flags: endconf\r\n");
+
+    xlog("L_INFO", "added dialplan conference-factory@features.invalid with conference id $var(conference-id) to invite\n"); 
+}
+
+
+# this is only used if we use X-Redirect-Server when handling the REFER
+route[EXTERNAL_TO_INTERNAL_RELAY_CONFERENCE_FACTORY_INVITE_REFER]
+{
+    if (!is_method("INVITE")) return;
+    if (!is_request()) return;
+    if (!($rU =~ "conference-factory\+")) return;
+
+    $var(conference-id) = $(rU{s.after,+}{s.before,+});
+    $var(conference-media-id) = $(rU{s.after,+}{s.after,+});
+
+    # $du should already be set
+
+    xlog("L_DEBUG", "DU => $du, conf => $var(conference-media-id)\n");
+    xlog("L_DEBUG", "DU => $du, conf => $sht(conference_duid=>$var(conference-media-id))\n");
+
+    append_hf("X-FS-Endpoint-Dialplan: conference-factory@features.invalid\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-ID: $var(conference-id)\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-Flags: join-only\r\n");
+
+    xlog("L_INFO", "added dialplan conference-factory@features.invalid with conference id $var(conference-id) to invite\n"); 
+
+}
+
+route[EXTERNAL_TO_INTERNAL_RELAY_CONFERENCE_FACTORY_REFER]
+{
+    if (!is_method("REFER")) return;
+    if (!is_request()) return;
+    if (!isflagset(FLAG_REGISTERED_ENDPOINT)) return;
+    if (!($(rt{uri.user}) =~ "conference-factory\+")) return;
+
+    $var(conference-id) = $(rt{uri.user}{s.after,+}{s.before,+});
+    $var(conference-media-id) = $(rt{uri.user}{s.after,+}{s.after,+});
+
+    xlog("L_DEBUG", "conference-id => $var(conference-id), conference-media-id => $var(conference-media-id)\n");
+    xlog("L_DEBUG", "DU => $du, refer-to-user => $(rt{uri.user}), refer-to => $rt\n");
+
+    $var(call-media-id) = "";
+    if (ds_is_from_list(-1, 2, "$du")) {
+        $var(call-media-id) = $(var(ds_attrs){param.value,duid});
+    }
+
+    xlog("L_DEBUG", "DU => $du, conf => $var(conference-media-id) , call => $var(call-media-id)\n");
+    xlog("L_DEBUG", "DU => $du, conf => $sht(conference_duid=>$var(conference-media-id)) , call => $sht(conference_duid=>$var(call-media-id))\n");
+
+    append_hf("X-FS-Endpoint-Dialplan: conference-factory@features.invalid\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-ID: $var(conference-id)\r\n");
+    append_hf("X-FS-Endpoint-Dialplan-Conference-Flags: join-only\r\n");
+
+    # redirect server
+    # REFER goes to freeswitch that sees X-Redirect-Server and does a deflect (REFER) back to A-leg
+    # which will then send a BYE and a new INVITE to the refer-to
+    # because we handle REFER from internal and do an association with X-Redirect-Server
+    # the INVITE gets routed to the correct media server
+    #
+    # this works only if endpoints are devices
+    # carriers usually don't support REFER
+    #
+    # if ($var(conference-media-id) != $var(call-media-id)) {
+    #     xlog("L_INFO", "adding Conference-Host => $(sht(conference_duid=>$var(conference-media-id)){uri.host})\n");
+    #     append_hf("X-Redirect-Server: $sht(conference_duid=>$var(conference-media-id))\r\n");
+    # }
+    #
+
+
+    # one alternative is to use different dialplans
+    # normal behaviour or
+    # cross server bridge into remote conference
+    # as we do with conferences app
+    # need to comment the above X-FS-Endpoint-Dialplan
+    # if ($var(conference-media-id) != $var(call-media-id)) {
+    #     append_hf("X-FS-Endpoint-Dialplan: conference-factory-remote@features.invalid\r\n");
+    # } else {
+    #     append_hf("X-FS-Endpoint-Dialplan: conference-factory-local@features.invalid\r\n");
+    # }
+
+    # another alternative is to change the dialplan
+    # so it handles a parameter that will indicate
+    # to do cross server bridge into remote conference
+    # as we do with conferences app
+    if ($var(conference-media-id) != "") {
+        if ($var(call-media-id) != "") {
+            if($var(conference-media-id) != $var(call-media-id)) {
+                $var(conference-host) = $sht(conference_duid=>$var(conference-media-id));
+                append_hf("X-FS-Endpoint-Dialplan-Conference-URI-Host: $var(conference-host)\r\n");
+                append_hf("X-FS-Endpoint-Dialplan-Conference-Host: $(var(conference-host){uri.host})\r\n");
+            }
+        }
+    }
+
+    xlog("L_INFO", "added dialplan conference-factory@features.invalid with conference id $var(conference-id) to refer\n"); 
+
+}
+
+## conference factory on cisco spa5xx adapter
+
+
+route[EXTERNAL_TO_INTERNAL_RELAY_CONFERENCE_FIX_CISCO_SDP]
+{
+    if (has_totag()) return;
+    if (!is_request()) return;
+    if (!is_method("INVITE")) return;
+    if ($ua == $null) return;
+    if (!($ua =~ "Cisco/SPA")) return;
+
+    replace_body_atonce("/8000/3", "/8000/1");
+}
+
+# vim: tabstop=4 softtabstop=4 shiftwidth=4 expandtab

--- a/kamailio/default.cfg
+++ b/kamailio/default.cfg
@@ -174,6 +174,9 @@ include_file "sip_trace_all-role.cfg"
 #!ifdef BLOCKER_ROLE
 include_file "blocker-role.cfg"
 #!endif
+#!ifdef CONFERENCE_FACTORY_ROLE
+include_file "conference-factory-role.cfg"
+#!endif
 
 ## sanity ##
 include_file "sanity.cfg"

--- a/kamailio/local.cfg
+++ b/kamailio/local.cfg
@@ -22,6 +22,7 @@
 # # #!trydef PRESENCE_NOTIFY_SYNC_ROLE
 # # #!trydef SIP_TRACE_ROLE
 # # #!trydef PUSH_NOTIFICATIONS_ROLE
+# # #!trydef CONFERENCE_FACTORY_ROLE
 
 ################################################################################
 ## SERVER INFORMATION


### PR DESCRIPTION
Background:
Make conference factory a role and load the related configuration automatically, so the standard installation doesn't require any further action beyond enabling the role.

This Merge Request:
Make Conference Factory a Role in Kamailio configuration

Related PRs: 
https://gitlab.com/oomaforbin/oomacorp/2600hz/kazoo-conference/-/merge_requests/1
https://github.com/2600hz/kazoo-configs-kamailio-extras/pull/11